### PR TITLE
`--api` command line argument accepts an optional admin API endpoint string

### DIFF
--- a/src/cfg_file_read_write.rs
+++ b/src/cfg_file_read_write.rs
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn test_find_peers_section_1() {
         let cfg_txt = "{
-            #commets
+            #comments
             Peers: [
                 tcp://some.peer.uri:34589
                 quic://another.peer.uri:55555 #comment
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn test_find_peers_section_5() {
         let cfg_txt = "{
-            #commets
+            #comments
             #Peers:
             #[
             #  tcp://some.peer.uri:34589

--- a/src/cfg_file_read_write.rs
+++ b/src/cfg_file_read_write.rs
@@ -182,7 +182,7 @@ fn find_end_of_peers_fragment(chars: &Vec<char>, from: usize, to: usize) -> usiz
     cur_pos
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "updating_cfg"))]
 mod tests {
     use super::*;
 

--- a/src/clap_args.rs
+++ b/src/clap_args.rs
@@ -58,7 +58,7 @@ pub fn build_args() -> clap::ArgMatches {
             arg!(
                 -r --restart "Restart the Yggdrasil (systemd or windows) service"
             )
-            .required(false)
+            .required(false),
         );
     }
 

--- a/src/clap_args.rs
+++ b/src/clap_args.rs
@@ -49,8 +49,12 @@ pub fn build_args() -> clap::ArgMatches {
                 -u --update_cfg "Make changes to the Yggdrasil configuration file. If not specified, no changes will be made to the file."
             )
             .required(false)
-        )
-        .arg(
+        );
+    }
+
+    #[cfg(any(feature = "updating_cfg", feature = "using_api"))]
+    {
+        app = app.arg(
             arg!(
                 -r --restart "Restart the Yggdrasil (systemd or windows) service"
             )
@@ -61,10 +65,14 @@ pub fn build_args() -> clap::ArgMatches {
     #[cfg(feature = "using_api")]
     {
         app = app.arg(
-            arg!(
-                -a --api "Add/remove peers during execution (requires enabling the admin API)"
-            )
-            .required(false),
+            Arg::new("api")
+                .short('a')
+                .long("api")
+                .default_missing_value("")
+                .value_name("SOCKET_ADDR")
+                .help("Add/remove peers during execution using admin API. Optionally accepts an admin socket endpoint URI (priority: CLI argument → AdminListen → platform defaults)")
+                .required(false)
+                .value_parser(value_parser!(String)),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,14 @@ fn main() {
         false
     };
 
-    let use_api = if cfg!(feature = "using_api") {
-        matches.get_flag("api")
+    #[allow(unused_variables)]
+    let (use_api, socket_addr) = if cfg!(feature = "using_api") {
+        match matches.get_one::<String>("api") {
+            Some(addr) => (true, if !addr.is_empty() { Some(addr) } else { None }),
+            _ => (false, None)
+        }
     } else {
-        false
+        (false, None)
     };
 
     if !(print_only || update_cfg || use_api) {
@@ -69,23 +73,51 @@ fn main() {
         }
     };
 
-    #[cfg(feature = "updating_cfg")]
-    if update_cfg {
+    #[cfg(any(feature = "updating_cfg", feature = "using_api"))]
+    const EMPTY_CFG: &str = "{}";
+
+    #[cfg(any(feature = "updating_cfg", feature = "using_api"))]
+    let cfg_txt = if update_cfg || use_api {
         // Checking if the file exists
         if !conf_path.exists() {
-            eprintln!("The Yggdrasil configuration file does not exist.");
-            process::exit(1);
-        }
+            // For `--update_cfg`, the config file is required so always warn and exit on errors
+            if update_cfg {
+                eprintln!("The Yggdrasil configuration file does not exist.");
+                process::exit(1);
+            }
 
-        // Checking write access to the configuration file
-        if let Err(e) = check_permissions(conf_path) {
-            eprintln!(
-                "There is no write access to the Yggdrasil configuration file ({}).",
-                e
-            );
-            process::exit(1);
+            // For `--api`, it is optional so substitute an empty config without warning
+            EMPTY_CFG.to_owned()
+        } else {
+            // Checking write access to the configuration file
+            #[cfg(feature = "updating_cfg")]
+            if update_cfg {
+                if let Err(e) = check_permissions(conf_path) {
+                    eprintln!(
+                        "There is no write access to the Yggdrasil configuration file ({}).",
+                        e
+                    );
+                    process::exit(1);
+                }
+            }
+
+            //Reading the configuration file (or failing) early
+            match cfg_file_read_write::read_config(conf_path) {
+                Ok(_ct) => _ct,
+                Err(e) => {
+                    // If the config file exists but cannot be read, warn in both cases but only exit if `--update_cfg`
+                    eprintln!("The configuration file cannot be read ({}).", e);
+                    if update_cfg {
+                        process::exit(1);
+                    }
+
+                    EMPTY_CFG.to_owned()
+                }
+            }
         }
-    }
+    } else {
+        EMPTY_CFG.to_owned()
+    };
 
     // Creating a temporary directory
     let tmp_dir = match tmpdir::create_tmp_dir(None) {
@@ -196,16 +228,7 @@ fn main() {
                 }
             };
 
-            //Reading the configuration file
-            let cfg_txt = match cfg_file_read_write::read_config(conf_path) {
-                Ok(_ct) => _ct,
-                Err(e) => {
-                    eprintln!("The configuration file cannot be read ({}).", e);
-                    process::exit(1);
-                }
-            };
-
-            let exrta_peers: Option<&String> = matches.get_one("extra");
+            let extra_peers: Option<&String> = matches.get_one("extra");
 
             // Adding peers to the configuration file
             #[cfg(feature = "updating_cfg")]
@@ -214,12 +237,13 @@ fn main() {
                     &peers,
                     conf_path,
                     n_peers,
-                    exrta_peers,
+                    extra_peers,
                     &cfg_txt,
                 );
             }
 
             //Restart if required
+            #[cfg(any(feature = "updating_cfg", feature = "using_api"))]
             if matches.get_flag("restart") {
                 #[cfg(not(target_os = "windows"))]
                 let _ = std::process::Command::new("systemctl")
@@ -252,7 +276,12 @@ fn main() {
                     }
                 };
 
-                using_api::update_peers(&peers, &mut conf_obj, n_peers, exrta_peers);
+                // If an API socket address was provided with `--api`, replace the one in the configuration
+                if let Some(addr) = socket_addr {
+                    conf_obj.insert("AdminListen".into(), nu_json::Value::String(addr.to_owned()));
+                }
+
+                using_api::update_peers(&peers, &mut conf_obj, n_peers, extra_peers);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     let (use_api, socket_addr) = if cfg!(feature = "using_api") {
         match matches.get_one::<String>("api") {
             Some(addr) => (true, if !addr.is_empty() { Some(addr) } else { None }),
-            _ => (false, None)
+            _ => (false, None),
         }
     } else {
         (false, None)
@@ -278,7 +278,10 @@ fn main() {
 
                 // If an API socket address was provided with `--api`, replace the one in the configuration
                 if let Some(addr) = socket_addr {
-                    conf_obj.insert("AdminListen".into(), nu_json::Value::String(addr.to_owned()));
+                    conf_obj.insert(
+                        "AdminListen".into(),
+                        nu_json::Value::String(addr.to_owned()),
+                    );
                 }
 
                 using_api::update_peers(&peers, &mut conf_obj, n_peers, extra_peers);


### PR DESCRIPTION
Nice tool, but I was missing the option to provide a custom admin API endpoint address (e.g. on OpenWrt with the LuCI Yggdrasil default installation, the socket location is something like `/tmp/yggdrasil/<interfacename>.sock`...), so added it as an optional string argument to the `--api` flag. If provided together with `--api`, it takes priority over AdminListen from the Yggdrasil configuration. If not provided, the previous logic is used.

Because there's now an additional user-provided source of the endpoint address, the config file itself is treated as optional for `--api` and generally whenever `--update_cfg` isn't used.

Made a few other small changes along the way as well, mostly for consistency of this logic with other things.